### PR TITLE
Fix gtk launch issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,19 @@ ksni = ["dep:ksni"]
 libappindicator = ["dep:libappindicator", "dep:gtk"]
 
 [target.'cfg(target_os="linux")'.dependencies]
-ksni = { version = "0.1.3", optional = true }
-libappindicator = { version = "0.7", optional = true } # Tray icon
-gtk = { version = "0.15", optional = true }
+ksni = { version = "0.2.0", optional = true }
+libappindicator = { version = "0.8", optional = true } # Tray icon
+gtk = { version = "0.16", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 padlock = "0.2"
-windows-sys = {version = "0.48.0", features = [
+windows-sys = { version = "0.48.0", features = [
     "Win32_Foundation",
-    "Win32_Graphics_Gdi", 
-    "Win32_System_LibraryLoader", 
-    "Win32_UI_Shell", 
-    "Win32_UI_WindowsAndMessaging"]}
+    "Win32_Graphics_Gdi",
+    "Win32_System_LibraryLoader",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 cocoa = "0.24"

--- a/src/api/linux_libappindicator/mod.rs
+++ b/src/api/linux_libappindicator/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{TIError, IconSource},
+    crate::{IconSource, TIError},
     gtk::prelude::*,
     libappindicator::{AppIndicator, AppIndicatorStatus},
 };
@@ -11,6 +11,7 @@ pub struct TrayItemLinux {
 
 impl TrayItemLinux {
     pub fn new(title: &str, icon: IconSource) -> Result<Self, TIError> {
+        gtk::init();
         let mut t = Self {
             tray: AppIndicator::new(title, icon.as_str()),
             menu: gtk::Menu::new(),


### PR DESCRIPTION
Updates crate versions and initialized GTK.
Related(FIxes): https://gitlab.subcom.tech/subcom/shepherd/-/issues/320

I've tested on my machine (KDE), the initial launch issue is fixed. The notification icon is not working due to dubs-broker-lauch error, which I think is system related. 

```
Failed to show notification: Error { kind: Zbus(InputOutput(Os { code: 2, kind: NotFound, message: "No such file or directory" })) }
```

Digging deeper, the "Not found" file is
```
AT-SPI: Error retrieving accessibility bus address: org.a11y.Bus.Error: Failed to execute child process ?/usr/bin/dbus-broker-launch? (No such file or directory)
```